### PR TITLE
Update Elliptic++_Transactions_Graph_Visualization.ipynb

### DIFF
--- a/Transactions Dataset/Elliptic++_Transactions_Graph_Visualization.ipynb
+++ b/Transactions Dataset/Elliptic++_Transactions_Graph_Visualization.ipynb
@@ -1654,6 +1654,8 @@
     {
       "cell_type": "code",
       "source": [
+        "df_merged = df_txs_features.merge(df_txs_classes[['txId', 'class']], on='txId', how='left')"
+        "df_txs_features['class'] = df_merged['class']"
         "list(df_txs_features.columns)"
       ],
       "metadata": {


### PR DESCRIPTION
df_txs_features.columns shows a column named `class` as well, but that is not part of the original df_txs_features. We need to merge df_txs_classes and df_txs_features on `txId` to get that column in df_txs_features.